### PR TITLE
Add `**kwargs` supports on pylru.lrudecorator

### DIFF
--- a/pylru.py
+++ b/pylru.py
@@ -502,13 +502,15 @@ class lrudecorator(object):
         self.cache = lrucache(size)
 
     def __call__(self, func):
-        def wrapped(*args):  # XXX What about kwargs
+        def wrapped(*args, **kwargs):
+            dispatch_uid = (hash(args),
+                            hash(tuple(sorted(kwargs.items()))))
             try:
-                return self.cache[args]
+                return self.cache[dispatch_uid]
             except KeyError:
                 pass
 
-            value = func(*args)
-            self.cache[args] = value
+            value = func(*args, **kwargs)
+            self.cache[dispatch_uid] = value
             return value
         return wrapped

--- a/test.py
+++ b/test.py
@@ -223,6 +223,16 @@ def testDecorator():
         assert square(x) == x*x
 
 
+@lrudecorator(25)
+def multiple(a, b):
+    return a*b
+
+def testDecoratorWithKwargs():
+    a = 10
+    for i in range(1000):
+        b = random.randint(0, 1493)
+        assert multiple(a, b=b) == a*b
+
 if __name__ == '__main__':
 
     random.seed()


### PR DESCRIPTION
I would like to use `lrudecorator` with `**kwargs` support thus I made this pull.
How do you like it?
