### PR TITLE
refactor(lrucache): improve lrucache.get()

### DIFF
--- a/pylru.py
+++ b/pylru.py
@@ -101,10 +101,10 @@ class lrucache(object):
 
     def get(self, key, default=None):
         """Get an item - return default (None) if not present"""
-        try:
-            return self[key]
-        except KeyError:
+        if key not in self.table:
             return default
+        
+        return self[key]
 
     def __setitem__(self, key, value):
         # First, see if any value is stored under 'key' in the cache already.


### PR DESCRIPTION
```sh
>>> timeit.repeat('cache.old_get(12138)', 'import pylru; cache = pylru.lrucache(3)', repeat=7)
[1.6048369407653809, 1.5690279006958008, 1.5801060199737549, 1.8120369911193848, 1.5470390319824219, 1.592298984527588, 1.5710852146148682]
>>> timeit.repeat('cache.get(12138)', 'import pylru; cache = pylru.lrucache(3)', repeat=7)
[0.24112796783447266, 0.23629999160766602, 0.23735690116882324, 0.23392081260681152, 0.23485207557678223, 0.23575401306152344, 0.24010705947875977]
```