### PR TITLE
lrucache support MutableMapping interface

### DIFF
--- a/pylru.py
+++ b/pylru.py
@@ -31,13 +31,17 @@
 # hash table under their associated key. The hash table allows efficient
 # lookup of values by key.
 
+
+import collections
+
+
 # Class for the node objects.
 class _dlnode(object):
     def __init__(self):
         self.empty = True
 
 
-class lrucache(object):
+class lrucache(collections.MutableMapping):
 
     def __init__(self, size, callback=None):
 
@@ -157,12 +161,6 @@ class lrucache(object):
         # being circular. Therefore, the ordering is already correct, we just
         # need to adjust the 'head' variable.
         self.head = node
-
-    def update(self, items):
-
-        # Add multiple items to the cache.
-        for n, v in items.items():
-            self[n] = v
 
     def __delitem__(self, key):
 


### PR DESCRIPTION
now new methods available: pop, popitem, update (replaced), setdefault

----
This PR makes `lrucache` object 100% compatible with dicts.
Actually i need one method - `pop`, but as i saw in commits history someone needs `update` method.
dict-like `update` method already provided by MutableMapping based on `__setitem__` implementation.

I don't edit `WriteThroughCacheManager` and `WriteBackCacheManager` cause len for `WriteBackCacheManager` should be calculated too difficult ( len(cache) + len(store)? )