### PR TITLE
Add optional callback funtionality to lrudecorator.

### DIFF
--- a/pylru.py
+++ b/pylru.py
@@ -554,8 +554,8 @@ def lruwrap(store, size, writeback=False):
 import functools
 
 class lrudecorator(object):
-    def __init__(self, size):
-        self.cache = lrucache(size)
+    def __init__(self, size, callback=None):
+        self.cache = lrucache(size, callback)
 
     def __call__(self, func):
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
The decorator is very useful, but sometimes using lru cache requires a callback when cache is full (example, pickling values in a database). The functionality is already here, so just add it to the decorator.