### PR TITLE
Minimize memory consumption of _dlnode

### DIFF
--- a/pylru.py
+++ b/pylru.py
@@ -39,6 +39,8 @@ else:
 
 # Class for the node objects.
 class _dlnode(object):
+    __slots__ = ('empty', 'next', 'prev', 'key', 'value')
+
     def __init__(self):
         self.empty = True
 


### PR DESCRIPTION
Added `__slots__` do `_dlnode` class (which saves 128 bytes per one object). 

Before this change, each _dlnode () object was consuming 208 bytes:

```python
from sys import getsizeof
d = _dlnode()
d.next = None
d.prev = None
d.key = None
d.value = None
assert getsizeof(d) + getsizeof(d.__dict__) == 208
```

After this change each _dlnode () object is consuming 80 bytes:

```python
from sys import getsizeof
d = _dlnode()
d.next = None
d.prev = None
d.key = None
d.value = None
assert getsizeof(d) == 80
```